### PR TITLE
feat(utils): Allow for profile and creds to have slightly different URLs

### DIFF
--- a/src/__tests__/unit/utils.spec.ts
+++ b/src/__tests__/unit/utils.spec.ts
@@ -119,6 +119,23 @@ describe('utils', () => {
       expect(result).toBe(true);
     });
 
+    it('should return true on mostly matching urls', () => {
+      const startUrl = 'test-startUrl';
+      const startLikeUrl = 'test-startUrl#/';
+      const cred: CachedCredential = {
+        ...testCredential,
+        startUrl: startLikeUrl,
+      };
+      const profile: Profile = {
+        ...testProfile,
+        sso_start_url: startUrl,
+      };
+
+      const result = utils.isMatchingStartUrl(cred, profile);
+
+      expect(result).toBe(true);
+    });
+
     it('should return false on un-matched urls', () => {
       const startUrl = 'test-startUrl';
       const cred: CachedCredential = {

--- a/src/__tests__/unit/utils.spec.ts
+++ b/src/__tests__/unit/utils.spec.ts
@@ -136,6 +136,16 @@ describe('utils', () => {
       expect(result).toBe(true);
     });
 
+    it('should return false when profile does not exist', () => {
+      const cred = testCredential;
+      const profile = undefined;
+
+      // @ts-expect-error Testing profile as undefined
+      const result = utils.isMatchingStartUrl(cred, profile);
+
+      expect(result).toBe(false);
+    });
+
     it('should return false on un-matched urls', () => {
       const startUrl = 'test-startUrl';
       const cred: CachedCredential = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,19 +54,22 @@ export const isMatchingStartUrl = (
   profile: Profile
 ): boolean => {
   let isMatch = false;
+  if (!profile || !profile.sso_start_url) {
+    return false;
+  }
   if (
-    profile?.sso_start_url.length > 0 &&
-    cred.startUrl.length != profile?.sso_start_url.length
+    profile.sso_start_url.length > 0 &&
+    cred.startUrl.length !== profile.sso_start_url.length
   ) {
-    isMatch = cred.startUrl.indexOf(profile?.sso_start_url) == 0;
+    isMatch = cred.startUrl.indexOf(profile.sso_start_url) === 0;
   } else {
-    isMatch = cred.startUrl === profile?.sso_start_url;
+    isMatch = cred.startUrl === profile.sso_start_url;
   }
 
   logger.debug(
     `Credential start url ${cred.startUrl} ${
       isMatch ? 'matches' : 'does not match'
-    } profile sso start url ${profile?.sso_start_url}`
+    } profile sso start url ${profile.sso_start_url}`
   );
   return isMatch;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,7 +53,16 @@ export const isMatchingStartUrl = (
   cred: CachedCredential,
   profile: Profile
 ): boolean => {
-  const isMatch = cred.startUrl === profile?.sso_start_url;
+  let isMatch = false;
+  if (
+    profile?.sso_start_url.length > 0 &&
+    cred.startUrl.length != profile?.sso_start_url.length
+  ) {
+    isMatch = cred.startUrl.indexOf(profile?.sso_start_url) == 0;
+  } else {
+    isMatch = cred.startUrl === profile?.sso_start_url;
+  }
+
   logger.debug(
     `Credential start url ${cred.startUrl} ${
       isMatch ? 'matches' : 'does not match'


### PR DESCRIPTION
Allow the url in the credential file to be longer than the url in profile

This happened after sso put a url ending in #/ but the profile it was checked against did not have
those characters.  This could have been me using the command line wrong or something like that, but I don't think it would be isolated to only me making such a mistake and running into this.

Thanks for reading these when I just dropped them without prior communication =/ Not a pattern I meant to follow.

I don't know why the coverage doesn't think that it is covering the new lines. The code fails without the change and works with it.