### PR TITLE
feat(sso): add support for new aws sso sessions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "editor.formatOnSave": true,
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ repo will be archived.
 
 ¹Renamed to IAM Identity Center as of July 26th, 2022.
 
+> **Note**
+> As of December 2022, profiles configured with an SSO Session Name using the
+> AWS CLI v2.8.2 or later have added functionality for the AWS SDKs to use SSO
+> credentials without them being present in the `~/.aws/credentials` file.
+>
+> This project **will** continue to be maintained and currently supports both legacy
+> and new profile formats, since I'm currently not aware if all third party AWS
+> tools have made changes required adopted this change (if any).
+>
+> See "[SSO token provider configuration with automatic authentication refresh][cli-auto-refresh-doc]"
+> for additional details.
+
 ## Install
 
 ```sh
@@ -80,6 +92,7 @@ alias awsmyprofile="awsp my-profile && ssocreds -p my-profile"
 [commitizen-img]:https://img.shields.io/badge/commitizen-friendly-brightgreen.svg
 [commitizen-url]:http://commitizen.github.io/cz-cli/
 [cli-sso-config-doc]:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html
+[cli-auto-refresh-doc]:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html#sso-configure-profile-token
 
 ## Contributors ✨
 

--- a/src/__tests__/doubles/dummies.ts
+++ b/src/__tests__/doubles/dummies.ts
@@ -1,13 +1,21 @@
-import { Profile, CachedCredential } from '../../types';
+import { CachedCredential, ProfileV1, ProfileV2 } from '../../types';
 import { RoleCredentials } from 'aws-sdk/clients/sso';
 
-export const testProfile: Profile = {
+export const testProfileV1: ProfileV1 = {
   output: 'json',
   region: 'us-east-1',
   sso_account_id: 'test-account-id',
   sso_region: 'us-east-1',
   sso_role_name: 'test-role-name',
   sso_start_url: 'test-start-url',
+};
+
+export const testProfileV2: ProfileV2 = {
+  output: 'json',
+  region: 'us-east-1',
+  sso_account_id: 'test-account-id',
+  sso_role_name: 'test-role-name',
+  sso_session: 'my-session',
 };
 
 export const testCredential: CachedCredential = {

--- a/src/__tests__/unit/errors.spec.ts
+++ b/src/__tests__/unit/errors.spec.ts
@@ -2,6 +2,7 @@ import {
   ExpiredCredsError,
   AwsSdkError,
   ProfileNotFoundError,
+  InvalidProfile,
 } from '../../errors';
 
 describe('Errors', () => {
@@ -48,6 +49,14 @@ describe('Errors', () => {
       const error = new ProfileNotFoundError('test');
 
       expect(error).toBeInstanceOf(ProfileNotFoundError);
+    });
+  });
+
+  describe('InvalidProfile', () => {
+    it('should be an instanceof InvalidProfile', () => {
+      const error = new InvalidProfile('test');
+
+      expect(error).toBeInstanceOf(InvalidProfile);
     });
   });
 });

--- a/src/__tests__/unit/type-guards.spec.ts
+++ b/src/__tests__/unit/type-guards.spec.ts
@@ -1,0 +1,114 @@
+import { ExpiredCredsError, AwsSdkError } from '../../errors';
+import {
+  isExpiredCredsError,
+  isSdkError,
+  isCredential,
+  isProfileV1,
+  isProfileV2,
+  isSSOSessionProfile,
+} from '../../type-guards';
+import {
+  CachedCredential,
+  ProfileV1,
+  ProfileV2,
+  SSOSessionProfile,
+} from '../../types';
+import { testCredential, testProfileV1, testProfileV2 } from '../doubles';
+
+describe('type guards', () => {
+  describe('isExpiredCredsError', () => {
+    it('should return true when passed an instance of ExpiredCredsError', () => {
+      const error = new ExpiredCredsError();
+
+      expect(isExpiredCredsError(error)).toBe(true);
+    });
+
+    it('should return false when passed a generic error', () => {
+      const error = new Error();
+
+      expect(isExpiredCredsError(error)).toBe(false);
+    });
+  });
+
+  describe('isSdkError', () => {
+    it('should return true when passed an instance of AwsSdkError', () => {
+      const error = new AwsSdkError();
+
+      expect(isSdkError(error)).toBe(true);
+    });
+
+    it('should return false when passed a generic error', () => {
+      const error = new Error();
+
+      expect(isSdkError(error)).toBe(false);
+    });
+  });
+
+  describe('isCredential', () => {
+    it('should return true when a credential is passed', () => {
+      const validCredential: CachedCredential = testCredential;
+
+      expect(isCredential(validCredential)).toBe(true);
+    });
+
+    it('should return false when an object without required props is passed', () => {
+      const validCredential: CachedCredential = {
+        ...testCredential,
+      };
+      delete validCredential.accessToken;
+
+      expect(isCredential(validCredential)).toBe(false);
+    });
+  });
+
+  describe('isProfileV1', () => {
+    it('should return true when profile version 1 is provided', () => {
+      const v1: ProfileV1 = testProfileV1;
+
+      expect(isProfileV1(v1)).toBe(true);
+    });
+
+    it('should return false when profile version 2 is provided', () => {
+      const v2: ProfileV2 = testProfileV2;
+
+      expect(isProfileV1(v2)).toBe(false);
+    });
+  });
+
+  describe('isProfileV2', () => {
+    it('should return true when profile version 1 is provided', () => {
+      const v2: ProfileV2 = testProfileV2;
+
+      expect(isProfileV2(v2)).toBe(true);
+    });
+
+    it('should return false when profile version 2 is provided', () => {
+      const v1: ProfileV1 = testProfileV1;
+
+      expect(isProfileV2(v1)).toBe(false);
+    });
+  });
+
+  describe('isSSOSessionProfile', () => {
+    it('should return true when a valid sso session profile is provided', () => {
+      const ssoProfile: SSOSessionProfile = {
+        sso_region: 'us-east-1',
+        sso_registration_scopes: 'sso:account:access',
+        sso_start_url: 'https://example.com',
+      };
+
+      expect(isSSOSessionProfile(ssoProfile)).toBe(true);
+    });
+
+    it('should return false when an invalid sso session profile is provided', () => {
+      const ssoProfile: SSOSessionProfile = {
+        sso_region: 'us-east-1',
+        sso_registration_scopes: 'sso:account:access',
+        sso_start_url: 'https://example.com',
+      };
+      delete ssoProfile.sso_start_url;
+
+      expect(isSSOSessionProfile(ssoProfile)).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/unit/utils.spec.ts
+++ b/src/__tests__/unit/utils.spec.ts
@@ -2,9 +2,8 @@ import fs from 'fs';
 import cp from 'child_process';
 import nodeUtil from 'util';
 import * as utils from '../../utils';
-import { CachedCredential, Profile } from '../../types';
-import { ExpiredCredsError, AwsSdkError } from '../../errors';
-import { testCredential, testProfile } from '../doubles';
+import { CachedCredential, MappedProfile } from '../../types';
+import { testCredential, testProfileV1 } from '../doubles';
 import { logger } from '../../logger';
 
 const filename = '/tmp/filename';
@@ -109,8 +108,8 @@ describe('utils', () => {
         ...testCredential,
         startUrl,
       };
-      const profile: Profile = {
-        ...testProfile,
+      const profile: MappedProfile = {
+        ...testProfileV1,
         sso_start_url: startUrl,
       };
 
@@ -126,8 +125,8 @@ describe('utils', () => {
         ...testCredential,
         startUrl: startLikeUrl,
       };
-      const profile: Profile = {
-        ...testProfile,
+      const profile: MappedProfile = {
+        ...testProfileV1,
         sso_start_url: startUrl,
       };
 
@@ -152,8 +151,8 @@ describe('utils', () => {
         ...testCredential,
         startUrl,
       };
-      const profile: Profile = {
-        ...testProfile,
+      const profile: MappedProfile = {
+        ...testProfileV1,
         sso_start_url: 'mismatched-start-url',
       };
 
@@ -200,27 +199,6 @@ describe('utils', () => {
     });
   });
 
-  describe('isCredential', () => {
-    it('should return true when a credential is passed', () => {
-      const validCredential: CachedCredential = testCredential;
-
-      const result = utils.isCredential(validCredential);
-
-      expect(result).toBe(true);
-    });
-
-    it('should return false when an object without required props is passed', () => {
-      const validCredential: CachedCredential = {
-        ...testCredential,
-      };
-      delete validCredential.accessToken;
-
-      const result = utils.isCredential(validCredential);
-
-      expect(result).toBe(false);
-    });
-  });
-
   describe('awsSsoLogin', () => {
     it('should invoke exec with the provided profileName', async () => {
       const profileName = 'test-profile';
@@ -245,42 +223,6 @@ describe('utils', () => {
 
       await expect(fn()).rejects.toThrow();
       expect(spy).toHaveBeenCalledWith(expected);
-    });
-  });
-
-  describe('isExpiredCredsError', () => {
-    it('should return true when passed an instance of ExpiredCredsError', () => {
-      const error = new ExpiredCredsError();
-
-      const result = utils.isExpiredCredsError(error);
-
-      expect(result).toBe(true);
-    });
-
-    it('should return false when passed a generic error', () => {
-      const error = new Error();
-
-      const result = utils.isExpiredCredsError(error);
-
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('isSdkError', () => {
-    it('should return true when passed an instance of AwsSdkError', () => {
-      const error = new AwsSdkError();
-
-      const result = utils.isSdkError(error);
-
-      expect(result).toBe(true);
-    });
-
-    it('should return false when passed a generic error', () => {
-      const error = new Error();
-
-      const result = utils.isSdkError(error);
-
-      expect(result).toBe(false);
     });
   });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -35,3 +35,15 @@ export class ProfileNotFoundError extends Error {
     Object.setPrototypeOf(this, ProfileNotFoundError.prototype);
   }
 }
+
+export class InvalidProfile extends Error {
+  constructor(profile: string) {
+    const message = `Invalid profile found for ${profile}`;
+    super(message);
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = message;
+
+    Object.setPrototypeOf(this, InvalidProfile.prototype);
+  }
+}

--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -1,0 +1,66 @@
+import { ExpiredCredsError, AwsSdkError } from './errors';
+import { logger } from './logger';
+import {
+  ProfileV1,
+  ProfileV2,
+  SSOSessionProfile,
+  CachedCredential,
+  ConfigFileEntry,
+} from './types';
+
+export const isExpiredCredsError = (e: unknown): e is ExpiredCredsError => {
+  const isExpErr = e instanceof ExpiredCredsError;
+  logger.debug(`Error is ${isExpErr ? '' : 'NOT '}an ExpiredCredsError`);
+  return isExpErr;
+};
+
+export const isSdkError = (e: unknown): e is AwsSdkError => {
+  const isSdkErr = e instanceof AwsSdkError;
+  logger.debug(`Error is ${isSdkErr ? '' : 'NOT '}an AwsSdkError`);
+  return isSdkErr;
+};
+
+export const isCredential = (
+  config: ConfigFileEntry | CachedCredential | unknown
+): config is CachedCredential => {
+  const isCred = Boolean(
+    // https://github.com/istanbuljs/istanbuljs/issues/516
+    /* istanbul ignore next */
+    (config as CachedCredential)?.accessToken &&
+      (config as CachedCredential).expiresAt
+  );
+  logger.debug(`Configuration is ${isCred ? '' : 'NOT '}a credential config`);
+  return isCred;
+};
+
+export const isProfileV1 = (profile: unknown): profile is ProfileV1 => {
+  const isV1 = Boolean(
+    /* istanbul ignore next */
+    (profile as ProfileV1)?.sso_start_url && (profile as ProfileV1).sso_region
+  );
+  console.log('evaluating if profile is v1', profile);
+  logger.debug(`Loaded profile is version ${isV1 ? '1' : ''}`);
+  return isV1;
+};
+
+export const isProfileV2 = (profile: unknown): profile is ProfileV2 => {
+  /* istanbul ignore next */
+  const isV2 = Boolean((profile as ProfileV2)?.sso_session);
+  logger.debug(`Loaded profile is version ${isV2 ? '2' : ''}`);
+  return isV2;
+};
+
+export const isSSOSessionProfile = (
+  profile: unknown
+): profile is SSOSessionProfile => {
+  const isSSOProfile = Boolean(
+    /* istanbul ignore next */
+    (profile as SSOSessionProfile)?.sso_region &&
+      (profile as SSOSessionProfile).sso_registration_scopes &&
+      (profile as SSOSessionProfile).sso_start_url
+  );
+  logger.debug(
+    `Loaded profile is ${isSSOProfile ? '' : 'NOT '}an SSO profile.`
+  );
+  return isSSOProfile;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,12 +9,40 @@ export interface RunArgs {
   proxyEnabled?: boolean;
 }
 
-export interface Profile {
+export type ConfigFileEntry = ProfileV1 | ProfileV2 | SSOSessionProfile;
+
+export interface MappedProfile {
   output: Output;
   region: Region;
   sso_account_id: AccountIdType;
   sso_region: Region;
   sso_role_name: RoleNameType;
+  sso_start_url: string;
+}
+
+/**
+ * Profile with legacy non-refreshable configuration.
+ */
+export type ProfileV1 = MappedProfile;
+
+/**
+ * Profile with SSO token provider configuration.
+ */
+export interface ProfileV2 {
+  output: Output;
+  region: Region;
+  sso_account_id: string;
+  sso_role_name: string;
+  sso_session: string;
+}
+
+/**
+ * SSO Sesssion profile when using profiles configured with the SSO token
+ * provider configuration.
+ */
+export interface SSOSessionProfile {
+  sso_region: Region;
+  sso_registration_scopes: string;
   sso_start_url: string;
 }
 


### PR DESCRIPTION
This change adds support for the new profile format that gets used when a user configures their AWS SSO profile with an AWS SSO Session. This change also retains backwards compatibility with the legacy profile versions so existing users should not see any change in functionality.

closes #59
